### PR TITLE
Add missing invalidator to `low-power-embedded-game`

### DIFF
--- a/exercises/concept/low-power-embedded-game/.meta/config.json
+++ b/exercises/concept/low-power-embedded-game/.meta/config.json
@@ -11,6 +11,9 @@
     ],
     "exemplar": [
       ".meta/exemplar.cairo"
+    ],
+    "invalidator": [
+      "Scarb.toml"
     ]
   },
   "blurb": "Learn tuples while writing convenience functions for a low-power embedded game"


### PR DESCRIPTION
```
(base) ➜  exercism-cairo git:(main) ./bin/configlet sync
Updating cached 'problem-specifications' data...
Checking exercises...
[warn] filepaths: unsynced: low-power-embedded-game
[warn] some exercises have unsynced filepaths
```

Configlet is complaining this concept exercise is missing an invalidator entry. The other exercises all seem to have it so I'm adding so configlet won't complain about it.