### PR TITLE
Add collatz-conjecture

### DIFF
--- a/config.json
+++ b/config.json
@@ -66,9 +66,19 @@
         "slug": "reverse-string",
         "name": "Reverse String",
         "uuid": "df9f3e80-acf5-41e0-9321-d4b13b26a036",
-        "practices": ["strings"],
+        "practices": [
+          "strings"
+        ],
         "prerequisites": [],
         "difficulty": 1
+      },
+      {
+        "slug": "collatz-conjecture",
+        "name": "Collatz Conjecture",
+        "uuid": "824df917-4f28-4fde-bb08-3bf101a52058",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 2
       },
       {
         "slug": "leap",

--- a/exercises/practice/collatz-conjecture/.docs/instructions.md
+++ b/exercises/practice/collatz-conjecture/.docs/instructions.md
@@ -1,0 +1,29 @@
+# Instructions
+
+The Collatz Conjecture or 3x+1 problem can be summarized as follows:
+
+Take any positive integer n.
+If n is even, divide n by 2 to get n / 2.
+If n is odd, multiply n by 3 and add 1 to get 3n + 1.
+Repeat the process indefinitely.
+The conjecture states that no matter which number you start with, you will always reach 1 eventually.
+
+Given a number n, return the number of steps required to reach 1.
+
+## Examples
+
+Starting with n = 12, the steps would be as follows:
+
+0. 12
+1. 6
+2. 3
+3. 10
+4. 5
+5. 16
+6. 8
+7. 4
+8. 2
+9. 1
+
+Resulting in 9 steps.
+So for input n = 12, the return value would be 9.

--- a/exercises/practice/collatz-conjecture/.meta/config.json
+++ b/exercises/practice/collatz-conjecture/.meta/config.json
@@ -1,0 +1,22 @@
+{
+  "authors": [
+    "BNAndras"
+  ],
+  "files": {
+    "solution": [
+      "src/lib.cairo"
+    ],
+    "test": [
+      "tests/collatz_conjecture.cairo"
+    ],
+    "example": [
+      ".meta/example.cairo"
+    ],
+    "invalidator": [
+      "Scarb.toml"
+    ]
+  },
+  "blurb": "Calculate the number of steps to reach 1 using the Collatz conjecture.",
+  "source": "An unsolved problem in mathematics named after mathematician Lothar Collatz",
+  "source_url": "https://en.wikipedia.org/wiki/3x_%2B_1_problem"
+}

--- a/exercises/practice/collatz-conjecture/.meta/example.cairo
+++ b/exercises/practice/collatz-conjecture/.meta/example.cairo
@@ -1,0 +1,14 @@
+pub fn steps(number: u64) -> u64 {
+    let mut working = number;
+    let mut count = 0;
+    while working > 1 {
+        if working % 2 == 0 {
+            working /= 2;
+        } else {
+            working = 3 * working + 1;
+        }
+        count += 1;
+    };
+
+    return count;
+}

--- a/exercises/practice/collatz-conjecture/.meta/example.cairo
+++ b/exercises/practice/collatz-conjecture/.meta/example.cairo
@@ -1,7 +1,5 @@
-pub fn steps(number: usize) -> Option<usize> {
-    if number == 0 {
-        return Option::None;
-    }
+pub fn steps(number: usize) -> usize {
+    assert!(number != 0, "Only positive integers are allowed");
 
     let mut working = number;
     let mut count = 0;
@@ -15,5 +13,5 @@ pub fn steps(number: usize) -> Option<usize> {
         count += 1;
     };
 
-    return Option::Some(count);
+    return count;
 }

--- a/exercises/practice/collatz-conjecture/.meta/example.cairo
+++ b/exercises/practice/collatz-conjecture/.meta/example.cairo
@@ -6,7 +6,6 @@ pub fn steps(number: usize) -> Option<usize> {
     let mut working = number;
     let mut count = 0;
 
-
     while working > 1 {
         if working % 2 == 0 {
             working /= 2;

--- a/exercises/practice/collatz-conjecture/.meta/example.cairo
+++ b/exercises/practice/collatz-conjecture/.meta/example.cairo
@@ -1,6 +1,12 @@
-pub fn steps(number: u64) -> u64 {
+pub fn steps(number: usize) -> Option<usize> {
+    if number == 0 {
+        return Option::None;
+    }
+
     let mut working = number;
     let mut count = 0;
+
+
     while working > 1 {
         if working % 2 == 0 {
             working /= 2;
@@ -10,5 +16,5 @@ pub fn steps(number: u64) -> u64 {
         count += 1;
     };
 
-    return count;
+    return Option::Some(count);
 }

--- a/exercises/practice/collatz-conjecture/.meta/tests.toml
+++ b/exercises/practice/collatz-conjecture/.meta/tests.toml
@@ -28,7 +28,6 @@ include = false
 [2187673d-77d6-4543-975e-66df6c50e2da]
 description = "zero is an error"
 reimplements = "7d4750e6-def9-4b86-aec7-9f7eb44f95a3"
-include = false
 
 [c6c795bf-a288-45e9-86a1-841359ad426d]
 description = "negative value is an error"

--- a/exercises/practice/collatz-conjecture/.meta/tests.toml
+++ b/exercises/practice/collatz-conjecture/.meta/tests.toml
@@ -1,0 +1,40 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[540a3d51-e7a6-47a5-92a3-4ad1838f0bfd]
+description = "zero steps for one"
+
+[3d76a0a6-ea84-444a-821a-f7857c2c1859]
+description = "divide if even"
+
+[754dea81-123c-429e-b8bc-db20b05a87b9]
+description = "even and odd steps"
+
+[ecfd0210-6f85-44f6-8280-f65534892ff6]
+description = "large number of even and odd steps"
+
+[7d4750e6-def9-4b86-aec7-9f7eb44f95a3]
+description = "zero is an error"
+include = false
+
+[2187673d-77d6-4543-975e-66df6c50e2da]
+description = "zero is an error"
+reimplements = "7d4750e6-def9-4b86-aec7-9f7eb44f95a3"
+include = false
+
+[c6c795bf-a288-45e9-86a1-841359ad426d]
+description = "negative value is an error"
+include = false
+
+[ec11f479-56bc-47fd-a434-bcd7a31a7a2e]
+description = "negative value is an error"
+reimplements = "c6c795bf-a288-45e9-86a1-841359ad426d"
+include = false

--- a/exercises/practice/collatz-conjecture/Scarb.toml
+++ b/exercises/practice/collatz-conjecture/Scarb.toml
@@ -1,0 +1,4 @@
+[package]
+name = "collatz_conjecture"
+version = "0.1.0"
+edition = "2023_11"

--- a/exercises/practice/collatz-conjecture/src/lib.cairo
+++ b/exercises/practice/collatz-conjecture/src/lib.cairo
@@ -1,3 +1,3 @@
-pub fn steps(number: usize) -> Option<usize> {
+pub fn steps(number: usize) -> usize {
     panic!("implement `steps`")
 }

--- a/exercises/practice/collatz-conjecture/src/lib.cairo
+++ b/exercises/practice/collatz-conjecture/src/lib.cairo
@@ -1,0 +1,3 @@
+pub fn steps(number: u64) -> u64 {
+    panic!("implement `steps`")
+}

--- a/exercises/practice/collatz-conjecture/src/lib.cairo
+++ b/exercises/practice/collatz-conjecture/src/lib.cairo
@@ -1,3 +1,3 @@
-pub fn steps(number: u64) -> u64 {
+pub fn steps(number: usize) -> Option<usize> {
     panic!("implement `steps`")
 }

--- a/exercises/practice/collatz-conjecture/tests/collatz_conjecture.cairo
+++ b/exercises/practice/collatz-conjecture/tests/collatz_conjecture.cairo
@@ -2,29 +2,30 @@ use collatz_conjecture::steps;
 
 #[test]
 fn zero_steps_for_one() {
-    assert_eq!(steps(1), Option::Some(0));
+    assert_eq!(steps(1), 0);
 }
 
 #[test]
 #[ignore]
 fn divide_if_even() {
-    assert_eq!(steps(16), Option::Some(4));
+    assert_eq!(steps(16), 4);
 }
 
 #[test]
 #[ignore]
 fn even_and_odd_steps() {
-    assert_eq!(steps(12), Option::Some(9));
+    assert_eq!(steps(12), 9);
 }
 
 #[test]
 #[ignore]
 fn large_number_of_even_and_odd_steps() {
-    assert_eq!(steps(1000000), Option::Some(152));
+    assert_eq!(steps(1000000), 152);
 }
 
 #[test]
 #[ignore]
+#[should_panic(expected: ("Only positive integers are allowed",))]
 fn zero_is_an_error() {
-    assert_eq!(steps(0), Option::None);
+    steps(0);
 }

--- a/exercises/practice/collatz-conjecture/tests/collatz_conjecture.cairo
+++ b/exercises/practice/collatz-conjecture/tests/collatz_conjecture.cairo
@@ -2,23 +2,29 @@ use collatz_conjecture::steps;
 
 #[test]
 fn zero_steps_for_one() {
-    assert_eq!(steps(1), 0);
+    assert_eq!(steps(1), Option::Some(0));
 }
 
 #[test]
 #[ignore]
 fn divide_if_even() {
-    assert_eq!(steps(16), 4);
+    assert_eq!(steps(16), Option::Some(4));
 }
 
 #[test]
 #[ignore]
 fn even_and_odd_steps() {
-    assert_eq!(steps(12), 9);
+    assert_eq!(steps(12), Option::Some(9));
 }
 
 #[test]
 #[ignore]
 fn large_number_of_even_and_odd_steps() {
-    assert_eq!(steps(1000000), 152);
+    assert_eq!(steps(1000000), Option::Some(152));
+}
+
+#[test]
+#[ignore]
+fn zero_is_an_error() {
+    assert_eq!(steps(0), Option::None);
 }

--- a/exercises/practice/collatz-conjecture/tests/collatz_conjecture.cairo
+++ b/exercises/practice/collatz-conjecture/tests/collatz_conjecture.cairo
@@ -1,0 +1,24 @@
+use collatz_conjecture::steps;
+
+#[test]
+fn zero_steps_for_one() {
+    assert_eq!(steps(1), 0);
+}
+
+#[test]
+#[ignore]
+fn divide_if_even() {
+    assert_eq!(steps(16), 4);
+}
+
+#[test]
+#[ignore]
+fn even_and_odd_steps() {
+    assert_eq!(steps(12), 9);
+}
+
+#[test]
+#[ignore]
+fn large_number_of_even_and_odd_steps() {
+    assert_eq!(steps(1000000), 152);
+}


### PR DESCRIPTION
For #48in24.

Towards #113 

`configlet create --practice-exercise <slug>` formats the track config so that's why the practices array for reverse string was edited. I used unsigned ints so the tests for zero or a negative number were skipped.
