### PR TITLE
Stop linting autogenerated exercise .md files

### DIFF
--- a/bin/lint_markdown.sh
+++ b/bin/lint_markdown.sh
@@ -1,7 +1,4 @@
 #!/usr/bin/env bash
 set -eo pipefail
 
-npx markdownlint-cli2 \
-    docs/*.md \
-    concepts/**/*.md \
-    exercises/**/*.md
+npx markdownlint-cli2 docs/*.md concepts/**/*.md


### PR DESCRIPTION
Makes little sense to lint autogenerated files - if Exercism deems the file well formatted, who are we to judge.

Prompted to update this by https://github.com/exercism/cairo/pull/141#issuecomment-2323203160