### PR TITLE
Add resistor-color-duo

### DIFF
--- a/config.json
+++ b/config.json
@@ -447,6 +447,14 @@
         ],
         "prerequisites": [],
         "difficulty": 10
+      },
+      {
+        "slug": "resistor-color-duo",
+        "name": "Resistor Color Duo",
+        "uuid": "5fd540f6-75d1-4b8f-ae56-08c246277e5d",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 2
       }
     ],
     "foregone": [

--- a/exercises/practice/resistor-color-duo/.docs/instructions.md
+++ b/exercises/practice/resistor-color-duo/.docs/instructions.md
@@ -1,0 +1,33 @@
+# Instructions
+
+If you want to build something using a Raspberry Pi, you'll probably use _resistors_.
+For this exercise, you need to know two things about them:
+
+- Each resistor has a resistance value.
+- Resistors are small - so small in fact that if you printed the resistance value on them, it would be hard to read.
+
+To get around this problem, manufacturers print color-coded bands onto the resistors to denote their resistance values.
+Each band has a position and a numeric value.
+
+The first 2 bands of a resistor have a simple encoding scheme: each color maps to a single number.
+For example, if they printed a brown band (value 1) followed by a green band (value 5), it would translate to the number 15.
+
+In this exercise you are going to create a helpful program so that you don't have to remember the values of the bands.
+The program will take color names as input and output a two digit number, even if the input is more than two colors!
+
+The band colors are encoded as follows:
+
+- black: 0
+- brown: 1
+- red: 2
+- orange: 3
+- yellow: 4
+- green: 5
+- blue: 6
+- violet: 7
+- grey: 8
+- white: 9
+
+From the example above:
+brown-green should return 15, and
+brown-green-violet should return 15 too, ignoring the third color.

--- a/exercises/practice/resistor-color-duo/.meta/config.json
+++ b/exercises/practice/resistor-color-duo/.meta/config.json
@@ -11,6 +11,9 @@
     ],
     "example": [
       ".meta/example.cairo"
+    ],
+    "invalidator": [
+      "Scarb.toml"
     ]
   },
   "blurb": "Convert color codes, as used on resistors, to a numeric value.",

--- a/exercises/practice/resistor-color-duo/.meta/config.json
+++ b/exercises/practice/resistor-color-duo/.meta/config.json
@@ -1,0 +1,19 @@
+{
+  "authors": [
+    "BNAndras"
+  ],
+  "files": {
+    "solution": [
+      "src/lib.cairo"
+    ],
+    "test": [
+      "tests/resistor_color_duo.cairo"
+    ],
+    "example": [
+      ".meta/example.cairo"
+    ]
+  },
+  "blurb": "Convert color codes, as used on resistors, to a numeric value.",
+  "source": "Maud de Vries, Erik Schierboom",
+  "source_url": "https://github.com/exercism/problem-specifications/issues/1464"
+}

--- a/exercises/practice/resistor-color-duo/.meta/example.cairo
+++ b/exercises/practice/resistor-color-duo/.meta/example.cairo
@@ -1,0 +1,32 @@
+#[derive(Copy, Debug, Drop)]
+pub enum Color {
+    Black,
+    Brown,
+    Red,
+    Orange,
+    Yellow,
+    Green,
+    Blue,
+    Violet,
+    Grey,
+    White,
+}
+
+pub fn value(colors: Array<Color>) -> u8 {
+    color_value(*colors[0]) * 10 + color_value(*colors[1])
+}
+
+fn color_value(color: Color) -> u8 {
+    match color {
+        Color::Black => 0,
+        Color::Brown => 1,
+        Color::Red => 2,
+        Color::Orange => 3,
+        Color::Yellow => 4,
+        Color::Green => 5,
+        Color::Blue => 6,
+        Color::Violet => 7,
+        Color::Grey => 8,
+        Color::White => 9,
+    }
+}

--- a/exercises/practice/resistor-color-duo/.meta/tests.toml
+++ b/exercises/practice/resistor-color-duo/.meta/tests.toml
@@ -1,0 +1,31 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[ce11995a-5b93-4950-a5e9-93423693b2fc]
+description = "Brown and black"
+
+[7bf82f7a-af23-48ba-a97d-38d59406a920]
+description = "Blue and grey"
+
+[f1886361-fdfd-4693-acf8-46726fe24e0c]
+description = "Yellow and violet"
+
+[b7a6cbd2-ae3c-470a-93eb-56670b305640]
+description = "White and red"
+
+[77a8293d-2a83-4016-b1af-991acc12b9fe]
+description = "Orange and orange"
+
+[0c4fb44f-db7c-4d03-afa8-054350f156a8]
+description = "Ignore additional colors"
+
+[4a8ceec5-0ab4-4904-88a4-daf953a5e818]
+description = "Black and brown, one-digit"

--- a/exercises/practice/resistor-color-duo/Scarb.toml
+++ b/exercises/practice/resistor-color-duo/Scarb.toml
@@ -1,0 +1,7 @@
+[package]
+name = "resistor_color_duo"
+version = "0.1.0"
+edition = "2024_07"
+
+[dev-dependencies]
+cairo_test = "2.7.1"

--- a/exercises/practice/resistor-color-duo/src/lib.cairo
+++ b/exercises/practice/resistor-color-duo/src/lib.cairo
@@ -1,0 +1,17 @@
+#[derive(Debug, Drop)]
+pub enum Color {
+    Black,
+    Brown,
+    Red,
+    Orange,
+    Yellow,
+    Green,
+    Blue,
+    Violet,
+    Grey,
+    White,
+}
+
+pub fn value(colors: Array<Color>) -> u8 {
+    panic!("implement `value`")
+}

--- a/exercises/practice/resistor-color-duo/tests/resistor_color_duo.cairo
+++ b/exercises/practice/resistor-color-duo/tests/resistor_color_duo.cairo
@@ -1,0 +1,63 @@
+use resistor_color_duo::{value, Color};
+
+#[test]
+fn brown_and_black() {
+    let colors = array![Color::Brown, Color::Black];
+    let output = value(colors);
+    let expected = 10;
+    assert_eq!(output, expected);
+}
+
+#[test]
+#[ignore]
+fn blue_and_grey() {
+    let colors = array![Color::Blue, Color::Grey];
+    let output = value(colors);
+    let expected = 68;
+    assert_eq!(output, expected);
+}
+
+#[test]
+#[ignore]
+fn yellow_and_violet() {
+    let colors = array![Color::Yellow, Color::Violet];
+    let output = value(colors);
+    let expected = 47;
+    assert_eq!(output, expected);
+}
+
+#[test]
+#[ignore]
+fn white_and_red() {
+    let colors = array![Color::White, Color::Red];
+    let output = value(colors);
+    let expected = 92;
+    assert_eq!(output, expected);
+}
+
+#[test]
+#[ignore]
+fn orange_and_orange() {
+    let colors = array![Color::Orange, Color::Orange];
+    let output = value(colors);
+    let expected = 33;
+    assert_eq!(output, expected);
+}
+
+#[test]
+#[ignore]
+fn ignore_additional_colors() {
+    let colors = array![Color::Green, Color::Brown, Color::Orange];
+    let output = value(colors);
+    let expected = 51;
+    assert_eq!(output, expected);
+}
+
+#[test]
+#[ignore]
+fn black_and_brown_one_digit() {
+    let colors = array![Color::Black, Color::Brown];
+    let output = value(colors);
+    let expected = 1;
+    assert_eq!(output, expected);
+}


### PR DESCRIPTION
Towards #223

I used an enum here so `resistor-color` and `resistor-color-trio` should also use similar enums for consistency. The intention is that a student works through these three exercises as a group, unlocking more complexity along the way.

Some tracks omit the test about ignoring additional colors. Exercism as a whole doesn't make a big deal of input validation except for a few specific exercises.  If we choose to not include the test, then we can use two Color parameters instead of the array.