### PR TITLE
Fix: call 'exit 1' only if test times out (fix command precedence)

### DIFF
--- a/bin/verify-exercises
+++ b/bin/verify-exercises
@@ -71,7 +71,7 @@ for exercise_path in $exercises; do
 
     cd "$tmp_dir"
 
-    timeout 20 scarb cairo-test --include-ignored || echo "$exercise timed out" && exit 1
+    timeout 20 scarb cairo-test --include-ignored || (echo "$exercise timed out" && exit 1)
 
     rm -rf "$tmp_dir"
 done


### PR DESCRIPTION
Addresses https://github.com/exercism/cairo/pull/274#issuecomment-2346764805