### PR TITLE
feat: add `grep` to foregone exercises

### DIFF
--- a/config.json
+++ b/config.json
@@ -857,6 +857,7 @@
       "bank-account",
       "complex-numbers",
       "gigasecond",
+      "grep",
       "hangman",
       "lens-person",
       "list-ops",


### PR DESCRIPTION
Closes #188 

Cairo was not built to work with files.