### PR TITLE
Remove generic [here] links

### DIFF
--- a/concepts/integers/about.md
+++ b/concepts/integers/about.md
@@ -67,6 +67,6 @@ fn main() {
 
 Each expression in these statements uses a mathematical operator and evaluates to a single value, which is then bound to a variable.
 
-List of all operators that Cairo provides can be found [here][operators].
+A list of all operators that Cairo provides [can be found here][operators].
 
 [operators]: https://book.cairo-lang.org/appendix-02-operators-and-symbols.html#operators

--- a/exercises/concept/health-statistics/.docs/hints.md
+++ b/exercises/concept/health-statistics/.docs/hints.md
@@ -7,7 +7,7 @@
 - The `new()` method receives the arguments we want to instantiate a `User` instance with.
   It should return an instance of `User` with the specified name, age, and weight.
 
-- See [here][structs] for additional examples on defining and instantiating structs.
+- Additional examples for defining and instantiating structs [are available here][structs].
 
 ## 2. Implement the getter methods
 
@@ -24,7 +24,7 @@ fn foo() -> i32 {
 }
 ```
 
-- See [here][methods] for some more examples of defining methods on structs.
+- Additional examples of defining methods on structs [are available here][methods].
 
 ## 3. Implement the setter methods
 


### PR DESCRIPTION
The Markdown lint GHA flags generic "[here]" link texts so hopefully this resolves that issue.