### PR TITLE
Format all `instructions.append.md` to start with an H1 (required but ignored) and H2

### DIFF
--- a/exercises/practice/anagram/.docs/instructions.append.md
+++ b/exercises/practice/anagram/.docs/instructions.append.md
@@ -1,3 +1,5 @@
 # Instructions Append
 
+## Implementation
+
 The anagrams can be returned in any order.

--- a/exercises/practice/binary-search-tree/.docs/instructions.append.md
+++ b/exercises/practice/binary-search-tree/.docs/instructions.append.md
@@ -1,5 +1,7 @@
 # Instructions append
 
+## Implementation
+
 Implementing an efficient and modifiable tree structure in Cairo (or any purely functional language with immutable memory) is challenging because these languages are designed to avoid changing data after it’s created.
 This immutability means that instead of updating a tree node directly, a new version of the tree must be created whenever you modify it.
 

--- a/exercises/practice/etl/.docs/instructions.append.md
+++ b/exercises/practice/etl/.docs/instructions.append.md
@@ -1,5 +1,7 @@
 # Instructions append
 
+## Implementation
+
 Because it is not possible in Cairo to iterate over `Felt252Dict` keys, the tests will only be verifying that the expected letter keys have the correct values in the dictionary.
 
 The tests are configured to ignore all other keys that may be set in the resulting dictionary.

--- a/exercises/practice/space-age/.docs/instructions.append.md
+++ b/exercises/practice/space-age/.docs/instructions.append.md
@@ -1,5 +1,7 @@
 # Instructions append
 
+## Implementation
+
 In Cairo, where there's no native support for floating-point numbers, we represent fractional values using integers.
 
 This approach is essential in blockchain development to maintain precision in calculations.


### PR DESCRIPTION
See related discussions [here](https://forum.exercism.org/t/grep-instructions-append-may-need-a-visible-header/53923) as well as https://github.com/exercism/docs/pull/592. Append files should all have an H1. Including an H2 helps break the flow from the non-append file to the append file so it does not read as the same stream of thought.